### PR TITLE
force skip flag to be sent when it's value is 0

### DIFF
--- a/video.go
+++ b/video.go
@@ -113,7 +113,7 @@ type Video struct {
 	//   If a bidder sends markup/creative that is itself skippable, the
 	//   Bid object should include the attr array with an element of
 	//   16 indicating skippable video. Refer to List 5.3.
-	Skip int8 `json:"skip"`
+	Skip *int8 `json:"skip,omitempty"`
 
 	// Attribute:
 	//   skipmin

--- a/video.go
+++ b/video.go
@@ -113,7 +113,7 @@ type Video struct {
 	//   If a bidder sends markup/creative that is itself skippable, the
 	//   Bid object should include the attr array with an element of
 	//   16 indicating skippable video. Refer to List 5.3.
-	Skip int8 `json:"skip,omitempty"`
+	Skip int8 `json:"skip"`
 
 	// Attribute:
 	//   skipmin


### PR DESCRIPTION
hey,
Trying to send video.skip with value 0 (for non skippable video) but since omitempty is presented in the video struct definition  seems like a problem.

thanks,