### PR TITLE
make secure field a pointer so zero value can be included in JSON

### DIFF
--- a/imp.go
+++ b/imp.go
@@ -152,7 +152,7 @@ type Imp struct {
 	//   creative assets and markup, where 0 = non-secure, 1 = secure.
 	//   If omitted, the secure state is unknown, but non-secure HTTP
 	//   support can be assumed.
-	Secure int8 `json:"secure,omitempty"`
+	Secure *int8 `json:"secure,omitempty"`
 
 	// Attribute:
 	//   iframebuster


### PR DESCRIPTION
As I've mentioned in #10, I've made `secure` a pointer, so zero value can be included into JSON structure instead of omitting it.