### PR TITLE
travis: only go 1.8.x and 1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,4 @@ language: go
 
 go:
   - 1.8.x
-  - 1.9.x
-  - 1.10.x
+  - 1.x


### PR DESCRIPTION
Test only with go 1.8.x (minimal required version) and 1.x (latest stable version)