### PR TITLE
Change native tracking method type and event type to int64

### DIFF
--- a/native1/event_tracking_method.go
+++ b/native1/event_tracking_method.go
@@ -1,7 +1,7 @@
 package native1
 
 // 7.7 Event Tracking Methods Table
-type EventTrackingMethod int8
+type EventTrackingMethod int64
 
 const (
 	EventTrackingMethodImage EventTrackingMethod = 1 // Image-pixel tracking - URL provided will be inserted as a 1x1 pixel at the time of the event.

--- a/native1/event_type.go
+++ b/native1/event_type.go
@@ -1,7 +1,7 @@
 package native1
 
 // 7.6 Event Types Table
-type EventType int8
+type EventType int64
 
 const (
 	EventTypeImpression      EventType = 1 // Impression


### PR DESCRIPTION
Both event type and event tracking type include exchange specific values that are over 500; they're currently set to int8 which has a maximum value of 127 and would cause an overflow error. To fix I changed them to int64.