### PR TITLE
v14: fix go module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# openrtb [![GoDoc](https://godoc.org/github.com/mxmCherry/openrtb?status.svg)](https://godoc.org/github.com/mxmCherry/openrtb) [![Build Status](https://travis-ci.org/mxmCherry/openrtb.svg?branch=master)](https://travis-ci.org/mxmCherry/openrtb)
+# openrtb [![GoDoc](https://godoc.org/github.com/mxmCherry/openrtb?status.svg)](https://pkg.go.dev/github.com/mxmCherry/openrtb/v14) [![Build Status](https://travis-ci.org/mxmCherry/openrtb.svg?branch=master)](https://travis-ci.org/mxmCherry/openrtb)
 
 [OpenRTB](https://iabtechlab.com/standards/openrtb/), [AdCOM](https://iabtechlab.com/standards/openmedia) and [OpenRTB Dynamic Native Ads](https://iabtechlab.com/standards/openrtb-native/) types for [Go programming language](https://golang.org/)
 
@@ -18,19 +18,19 @@ This library is tested with Go 1.9+ since [v12.0.0](https://github.com/mxmCherry
 # Using
 
 ```bash
-go get -u "github.com/mxmCherry/openrtb/..."
+go get -u "github.com/mxmCherry/openrtb/v14/..."
 ```
 
 ```go
 import (
-	openrtb2 "github.com/mxmCherry/openrtb/openrtb2"
+	openrtb2 "github.com/mxmCherry/openrtb/v14/openrtb2"
 
-	openrtb3 "github.com/mxmCherry/openrtb/openrtb3"
-	adcom1 "github.com/mxmCherry/openrtb/adcom1"
+	openrtb3 "github.com/mxmCherry/openrtb/v14/openrtb3"
+	adcom1 "github.com/mxmCherry/openrtb/v14/adcom1"
 
-	native1 "github.com/mxmCherry/openrtb/native1"
-	nreq "github.com/mxmCherry/openrtb/native1/request"
-	nres "github.com/mxmCherry/openrtb/native1/response"
+	native1 "github.com/mxmCherry/openrtb/v14/native1"
+	nreq "github.com/mxmCherry/openrtb/v14/native1/request"
+	nres "github.com/mxmCherry/openrtb/v14/native1/response"
 )
 ```
 
@@ -66,7 +66,7 @@ Pointer | Omitempty | When to use                                               
 
 Using both pointer and `omitempty` is mostly just to save traffic / generate more "canonical" (strict) JSON.
 
-## Documentation ([godoc](https://godoc.org/github.com/mxmCherry/openrtb))
+## Documentation ([pkg.go.dev](https://pkg.go.dev/github.com/mxmCherry/openrtb/v14))
 - [Godoc: documenting Go code](http://blog.golang.org/godoc-documenting-go-code)
 - Each entity (type, struct key or constant) should be documented
 - Comments for entities should be copy-pasted "as-is" from OpenRTB specification (except section 5 - replace "table" with "list" there; ideally, each sentence must be on a new line)

--- a/adcom1/README.md
+++ b/adcom1/README.md
@@ -1,3 +1,3 @@
-# adcom1 [![GoDoc](https://godoc.org/github.com/mxmCherry/openrtb/adcom1?status.svg)](https://godoc.org/github.com/mxmCherry/openrtb/adcom1)
+# adcom1 [![GoDoc](https://godoc.org/github.com/mxmCherry/openrtb/adcom1?status.svg)](https://pkg.go.dev/github.com/mxmCherry/openrtb/v14/adcom1)
 
 [AdCOM](https://iabtechlab.com/standards/openmedia/) [1.0](https://github.com/InteractiveAdvertisingBureau/AdCOM) types for [Go programming language](https://golang.org/)

--- a/adcom1/adcom1_test.go
+++ b/adcom1/adcom1_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
-	. "github.com/mxmCherry/openrtb/adcom1"
+	. "github.com/mxmCherry/openrtb/v14/adcom1"
 )
 
 var _ = DescribeTable(

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mxmCherry/openrtb
+module github.com/mxmCherry/openrtb/v14
 
 go 1.12
 

--- a/native1/README.md
+++ b/native1/README.md
@@ -1,4 +1,4 @@
-# native1 [![GoDoc](https://godoc.org/github.com/mxmCherry/openrtb/native1?status.svg)](https://godoc.org/github.com/mxmCherry/openrtb/native1)
+# native1 [![GoDoc](https://godoc.org/github.com/mxmCherry/openrtb/native1?status.svg)](https://pkg.go.dev/github.com/mxmCherry/openrtb/v14/native1)
 
 [OpenRTB Dynamic Native Ads API](https://iabtechlab.com/standards/openrtb-native/) [1.2](https://iabtechlab.com/wp-content/uploads/2016/07/OpenRTB-Native-Ads-Specification-Final-1.2.pdf) section "7 Reference Lists/Enumerations" types for [Go programming language](https://golang.org/)
 

--- a/native1/request/README.md
+++ b/native1/request/README.md
@@ -1,3 +1,3 @@
-# native1/request [![GoDoc](https://godoc.org/github.com/mxmCherry/openrtb/native1/request?status.svg)](https://godoc.org/github.com/mxmCherry/openrtb/native1/request)
+# native1/request [![GoDoc](https://godoc.org/github.com/mxmCherry/openrtb/native1/request?status.svg)](https://pkg.go.dev/github.com/mxmCherry/openrtb/v14/native1/request)
 
 [OpenRTB Dynamic Native Ads API](https://iabtechlab.com/standards/openrtb-native/) [1.2](https://iabtechlab.com/wp-content/uploads/2016/07/OpenRTB-Native-Ads-Specification-Final-1.2.pdf) section "4 Native Ad Request Markup Details" types for [Go programming language](https://golang.org/)

--- a/native1/request/data.go
+++ b/native1/request/data.go
@@ -3,7 +3,7 @@ package request
 import (
 	"encoding/json"
 
-	"github.com/mxmCherry/openrtb/native1"
+	"github.com/mxmCherry/openrtb/v14/native1"
 )
 
 // 4.6 Data Object

--- a/native1/request/event_tracker.go
+++ b/native1/request/event_tracker.go
@@ -3,7 +3,7 @@ package request
 import (
 	"encoding/json"
 
-	"github.com/mxmCherry/openrtb/native1"
+	"github.com/mxmCherry/openrtb/v14/native1"
 )
 
 // 4.7 Event Trackers Request Object

--- a/native1/request/image.go
+++ b/native1/request/image.go
@@ -3,7 +3,7 @@ package request
 import (
 	"encoding/json"
 
-	"github.com/mxmCherry/openrtb/native1"
+	"github.com/mxmCherry/openrtb/v14/native1"
 )
 
 // 4.4 Image Object

--- a/native1/request/request.go
+++ b/native1/request/request.go
@@ -8,7 +8,7 @@ package request
 import (
 	"encoding/json"
 
-	"github.com/mxmCherry/openrtb/native1"
+	"github.com/mxmCherry/openrtb/v14/native1"
 )
 
 // 4.1 Native Markup Request Object

--- a/native1/request/request_test.go
+++ b/native1/request/request_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
-	. "github.com/mxmCherry/openrtb/native1/request"
+	. "github.com/mxmCherry/openrtb/v14/native1/request"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"

--- a/native1/request/video.go
+++ b/native1/request/video.go
@@ -3,7 +3,7 @@ package request
 import (
 	"encoding/json"
 
-	"github.com/mxmCherry/openrtb/native1"
+	"github.com/mxmCherry/openrtb/v14/native1"
 )
 
 // 4.5 Video Object

--- a/native1/response/README.md
+++ b/native1/response/README.md
@@ -1,3 +1,3 @@
-# native1/response [![GoDoc](https://godoc.org/github.com/mxmCherry/openrtb/native1/response?status.svg)](https://godoc.org/github.com/mxmCherry/openrtb/native1/response)
+# native1/response [![GoDoc](https://godoc.org/github.com/mxmCherry/openrtb/native1/response?status.svg)](https://pkg.go.dev/github.com/mxmCherry/openrtb/v14/native1/response)
 
 [OpenRTB Dynamic Native Ads API](https://iabtechlab.com/standards/openrtb-native/) [1.2](https://iabtechlab.com/wp-content/uploads/2016/07/OpenRTB-Native-Ads-Specification-Final-1.2.pdf) section "5 Native Ad Response Markup Details" types for [Go programming language](https://golang.org/)

--- a/native1/response/data.go
+++ b/native1/response/data.go
@@ -3,7 +3,7 @@ package response
 import (
 	"encoding/json"
 
-	"github.com/mxmCherry/openrtb/native1"
+	"github.com/mxmCherry/openrtb/v14/native1"
 )
 
 // 5.5 Object: Data

--- a/native1/response/event_tracker.go
+++ b/native1/response/event_tracker.go
@@ -3,7 +3,7 @@ package response
 import (
 	"encoding/json"
 
-	"github.com/mxmCherry/openrtb/native1"
+	"github.com/mxmCherry/openrtb/v14/native1"
 )
 
 // 5.8 Event Tracker Response Object

--- a/native1/response/image.go
+++ b/native1/response/image.go
@@ -3,7 +3,7 @@ package response
 import (
 	"encoding/json"
 
-	"github.com/mxmCherry/openrtb/native1"
+	"github.com/mxmCherry/openrtb/v14/native1"
 )
 
 // 5.4 Object: Image

--- a/native1/response/response_test.go
+++ b/native1/response/response_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
-	. "github.com/mxmCherry/openrtb/native1/response"
+	. "github.com/mxmCherry/openrtb/v14/native1/response"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"

--- a/openrtb2/README.md
+++ b/openrtb2/README.md
@@ -1,3 +1,3 @@
-# openrtb2 [![GoDoc](https://godoc.org/github.com/mxmCherry/openrtb/openrtb2?status.svg)](https://godoc.org/github.com/mxmCherry/openrtb/openrtb2)
+# openrtb2 [![GoDoc](https://godoc.org/github.com/mxmCherry/openrtb/openrtb2?status.svg)](https://pkg.go.dev/github.com/mxmCherry/openrtb/v14/openrtb2)
 
 [OpenRTB](https://iabtechlab.com/standards/openrtb/) [2.5](https://iabtechlab.com/wp-content/uploads/2016/07/OpenRTB-API-Specification-Version-2-5-FINAL.pdf) types for [Go programming language](https://golang.org/)

--- a/openrtb2/bid_request_test.go
+++ b/openrtb2/bid_request_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
-	. "github.com/mxmCherry/openrtb/openrtb2"
+	. "github.com/mxmCherry/openrtb/v14/openrtb2"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"

--- a/openrtb2/bid_response_test.go
+++ b/openrtb2/bid_response_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
-	. "github.com/mxmCherry/openrtb/openrtb2"
+	. "github.com/mxmCherry/openrtb/v14/openrtb2"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"

--- a/openrtb3/README.md
+++ b/openrtb3/README.md
@@ -1,3 +1,3 @@
-# openrtb3 [![GoDoc](https://godoc.org/github.com/mxmCherry/openrtb/openrtb3?status.svg)](https://godoc.org/github.com/mxmCherry/openrtb/openrtb3)
+# openrtb3 [![GoDoc](https://godoc.org/github.com/mxmCherry/openrtb/openrtb3?status.svg)](https://pkg.go.dev/github.com/mxmCherry/openrtb/v14/openrtb3)
 
 [OpenRTB](https://iabtechlab.com/standards/openrtb/) [3.0](https://github.com/InteractiveAdvertisingBureau/openrtb) types for [Go programming language](https://golang.org/)

--- a/openrtb3/openrtb3_test.go
+++ b/openrtb3/openrtb3_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
-	. "github.com/mxmCherry/openrtb/openrtb3"
+	. "github.com/mxmCherry/openrtb/v14/openrtb3"
 
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"


### PR DESCRIPTION
https://blog.golang.org/v2-go-modules

Roughly, just a:

```shell
find -type f -iname '*.go' | xargs -I {} sed -i 's/mxmCherry\/openrtb/mxmCherry\/openrtb\/v14/g' {}
find -type f -iname '*.go' | xargs -I {} goimports -w {}
```

Also, point to pkg.go.dev for documentation (old godoc.org badge kept kill pkg.go.dev provides its own).