### PR TITLE
Make native response asset ID a pointer

### DIFF
--- a/native1/response/asset.go
+++ b/native1/response/asset.go
@@ -18,7 +18,7 @@ type Asset struct {
 	//   int
 	// Description:
 	//   Optional if assetsurl/dcourl is being used; required if embedded asset is being used.
-	ID int64 `json:"id,omitempty"`
+	ID *int64 `json:"id,omitempty"`
 
 	// Field:
 	//   required


### PR DESCRIPTION
As mentioned in https://github.com/mxmCherry/openrtb/issues/44 an ID with a zero value is lost when marshalling.
This PR makes it into a pointer to avoid the issue.