### PR TITLE
convert coppa field to pointer

### DIFF
--- a/openrtb2/regs.go
+++ b/openrtb2/regs.go
@@ -16,7 +16,7 @@ type Regs struct {
 	//   Flag indicating if this request is subject to the COPPA
 	//   regulations established by the USA FTC, where 0 = no, 1 = yes.
 	//   Refer to Section 7.5 for more information.
-	COPPA int8 `json:"coppa,omitempty"`
+	COPPA *int8 `json:"coppa,omitempty"`
 
 	// Attribute:
 	//   gdpr


### PR DESCRIPTION
COPPA should be changed to a pointer type so it can be set to 0. Currently, the omitempty will not marshal the value if it is 0. This PR addresses (https://github.com/mxmCherry/openrtb/issues/50).