### PR TITLE
native: change Video data type into openrtb2.Video

### DIFF
--- a/native1/request/asset.go
+++ b/native1/request/asset.go
@@ -79,6 +79,8 @@ type Asset struct {
 	//   Note that in-stream (ie preroll, etc) video ads are not part of Native.
 	//   Native ads may contain a video as the ad creative itself.
 	//   Each asset object may contain only one of title, img, data or video.
+	// Note:
+	//   Video object Refer to openrtb2.Video
 	Video *Video `json:"video,omitempty"`
 
 	// Field:

--- a/native1/request/video.go
+++ b/native1/request/video.go
@@ -1,9 +1,7 @@
 package request
 
 import (
-	"encoding/json"
-
-	"github.com/mxmCherry/openrtb/v16/native1"
+	"github.com/mxmCherry/openrtb/v16/openrtb2"
 )
 
 // 4.5 Video Object
@@ -13,57 +11,5 @@ import (
 // Exchange implementers can impose their own specific restrictions.
 // Here are the required attributes of the Video Object.
 // For optional attributes please refer to OpenRTB.
-type Video struct {
-	// Field:
-	//   mimes
-	// Scope:
-	//   required
-	// Type:
-	//   array of string
-	// Description:
-	//   Content MIME types supported.
-	//   Popular MIME types include,but are not limited to “video/x-mswmv” for Windows Media, and “video/x-flv” for Flash Video, or “video/mp4”.
-	//   Note that native1 frequently does not support flash.
-	MIMEs []string `json:"mimes"`
 
-	// Field:
-	//   minduration
-	// Scope:
-	//   required
-	// Type:
-	//   integer
-	// Description:
-	//   Minimum video ad duration in seconds.
-	MinDuration int64 `json:"minduration"`
-
-	// Field:
-	//   maxduration
-	// Scope:
-	//   required
-	// Type:
-	//   integer
-	// Description:
-	//   Maximum video ad duration in seconds.
-	MaxDuration int64 `json:"maxduration"`
-
-	// Field:
-	//   protocols
-	// Scope:
-	//   required
-	// Type:
-	//   array of integers
-	// Description:
-	//   An array of video protocols the publisher can accept in the bid response.
-	//   See OpenRTB Table ‘Video Bid Response Protocols’ for a list of possible values.
-	Protocols []native1.Protocol `json:"protocols"`
-
-	// Field:
-	//   ext
-	// Scope:
-	//   optional
-	// Type:
-	//   object
-	// Description:
-	// This object is a placeholder that may contain custom JSON agreed to by the parties to support flexibility beyond the standard defined in this specification
-	Ext json.RawMessage `json:"ext,omitempty"`
-}
+type Video = openrtb2.Video


### PR DESCRIPTION
Implements #52. Using type alias to achieve, retain annotation in `native1.Video.go` so that we could know why